### PR TITLE
MT-6899 core lib update does not support cocoapods

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,32 +3,29 @@
 
 # Overview
 
-The what3words Swift API wrapper converts a spoken 3 word address in audio to a list of three word address suggestions.
+The what3words Swift API wrapper enables the conversion of a spoken 3 word address in audio to a list of three word address suggestions.
 
 # Authentication
 
-To use this library you’ll need a what3words API key, which can be signed up for [here](https://what3words.com/select-plan), and then you will have to add a Voice API plan in your [account](https://accounts.what3words.com/billing).
+To use this library, you’ll need a what3words API key, which can be obtained [here](https://what3words.com/select-plan). If you wish to use Voice API calls, add a Voice API plan to your [account](https://accounts.what3words.com/billing).
+
 
 # Example
 
-An iOS UIKit example using the VoiceAPI is provided in this package: [https://github.com/what3words/w3w-swift-samples/tree/main/VoiceAPI](https://github.com/what3words/w3w-swift-samples/tree/main/VoiceAPI)
+An iOS UIKit example using the Voice API is provided in this package: [./Examples/VoiceAPI/VoiceAPI.xcodeproj](./Examples/VoiceAPI/VoiceAPI.xcodeproj)
 
 # Installation
 
-You can install this with [Swift Package Manager](https://developer.apple.com/documentation/xcode/adding_package_dependencies_to_your_app) by adding the URL below to Swift Packages under your project settings:
-
-```
-https://github.com/what3words/w3w-swift-voice-api.git
-```
+The Voice API wrapper is included in what3words' [Swift API Wrapper](https://github.com/what3words/w3w-swift-wrapper) code.  Installation instructions can be found in its [README](README.md).
 
 ## Usage
 
 ### Import
 
-In any swift file you use the what3words API, use the following :
+In any Swift file where you use the what3words API, import:
 
 ```swift
-import W3WSwiftVoiceApi
+import W3WSwiftApi
 ```
 
 ### Initialise
@@ -36,11 +33,11 @@ import W3WSwiftVoiceApi
 Initialize the W3W API class:
 
 ```swift
-var api = W3WVoiceApi(apiKey: "YourApiKey")
+let api = What3WordsV3(apiKey: "YourApiKey")
 ```
 
 ##### Example
-This example instantiates a `W3WMicrophone` which provides an audio stream to `autosuggest(audio:)` which begins recording when `autosuggest` is called.
+This example instantiates a `W3WMicrophone` which provides an audio stream to `autosuggest(audio:)` and begins recording when `autosuggest` is called.
 
 ```swift
 // instantiate the API
@@ -58,15 +55,15 @@ api.autosuggest(audio: microphone, language: "en") { suggestions, error in
 ```
 
 
-The `W3WMicrophone` class uses the device's microphone and provides an audio stream to `autosuggest(audio:)`.  The `autosuggest(audio:)` function is clever enough to call `microphone.start()` if it sees that a W3WMicrophone is passed in.
+The `W3WMicrophone` class uses the device's microphone and provides an audio stream to `autosuggest(audio:)`, which will automatically call `microphone.start()` when passed W3WMicrophone instance.
 
 ### Options
 
-The same options are available as in the core API calls which are laid out in the [API documentation](https://developer.what3words.com/public-api/docs#autosuggest).
+The same options as in the core API calls are available for Voice API calls, detailed in the [API documentation](https://developer.what3words.com/public-api/docs#autosuggest).
 
 ##### Example
 
-Ask for results focused around particular coordinates:
+Focus results around specific coordinates.
 
 ```swift
 // coords
@@ -86,7 +83,7 @@ api.autosuggest(audio: microphone, language: "en", options: options) { suggestio
 
 #### Languages
 
-You can call `availableVoiceLanguages(completion:)` to get a list of currently supported languages:
+Retrieve the list of currently supported languages with `availableVoiceLanguages(completion:)`:
 
 ```Swift
 api.availableVoiceLanguages() { languages, error in
@@ -99,7 +96,7 @@ api.availableVoiceLanguages() { languages, error in
 
 #### User Feedback
 
-You may want to show microphone feedback graphically in your app. The W3WMicrophone class has a closure variable that is called intermittently providing audio amplitude information:
+The `W3WMicrophone` class includes a volumeUpdate closure, which is called intermittently to provide audio amplitude data, useful for visual feedback.
 
 ```Swift
 public var volumeUpdate: (Double) -> ()
@@ -113,9 +110,9 @@ microphone?.volumeUpdate = { volume in
 }
 ```
 
-### Bring your own audio data
+### Using Custom Audio Data
 
-To use an audio stream that is not captured by W3WMicrophone, perhaps something streaming, or a bespoke device, use `W3WAudioStream` and pass it to `autosuggest(audio: W3WAudioStream)` instead.  Call `add(samples:)` while there is data to send and call `endSamples()` after the last data.
+For custom audio data sources (e.g., streaming audio or bespoke devices), use `W3WAudioStream` and pass it to `autosuggest(audio: W3WAudioStream)`. Send data via `add(samples:)`, ending with `endSamples()` when done.
 
 ##### Example:
 
@@ -136,8 +133,19 @@ api.autosuggest(audio: audio, language: "en") { suggestions, error in
 
 // start sending audio data to autosuggest via the audio stream
 while (yourSoundObject.isProducingAudio() {
-	audio.add(samples: yourSoundObject.getNextSampleSet())
+    audio.add(samples: yourSoundObject.getNextSampleSet())
 }
 audio.endSamples()
 
 ```
+
+### Alternative Approach
+
+The Voice API is implemented as an extension of `What3WordsV3`, adding an additional `autosuggest(audio:)` function. This allows separation of the Voice API code from the main API functions if needed.
+
+If only the Voice API is required, instantiate `W3WVoiceApi` directly:
+```swift
+let voiceApi = W3WVoiceApi(apiKey: "YourApiKey")
+```
+
+The two functions are the same: `autosuggest(audio:completion:)` and `availableVoiceLanguages(completion:)`.

--- a/Tests/w3w-swift-wrapper-voiceTests/w3w_swift_wrapperTests.swift
+++ b/Tests/w3w-swift-wrapper-voiceTests/w3w_swift_wrapperTests.swift
@@ -8,7 +8,7 @@ import XCTest
 final class w3w_swift_wrapperTests: XCTestCase {
   
   
-  var api:W3WVoiceApi!
+  var api: W3WVoiceApi!
   
   
   override func setUp() {
@@ -84,6 +84,8 @@ final class w3w_swift_wrapperTests: XCTestCase {
 //    
 //    let somewhereInLondon = CLLocationCoordinate2D(latitude: 51.520847,longitude: -0.195521)
 //    
+//     
+//      
 //    if let resource = try? Resource(name: "test", type: "dat") {
 //      
 //      // load a file of raw audio data containing a mono stream of 32 bit float data samples
@@ -93,7 +95,7 @@ final class w3w_swift_wrapperTests: XCTestCase {
 //        let audio = W3WAudioStream(sampleRate: 44100, encoding: .pcm_f32le)
 //        
 //        // assign the audio stream to an autosuggest call
-//        api.autosuggest(audio: audio, language: "en", options: W3WOption.focus(somewhereInLondon)) { suggestions, error in
+//          api.autosuggest(audio: audio, language: W3WBaseLanguage(locale: "en"), options: W3WOption.focus(somewhereInLondon)) { suggestions, error in
 //          
 //          XCTAssertNil(error)
 //          
@@ -101,9 +103,19 @@ final class w3w_swift_wrapperTests: XCTestCase {
 //            expectation.fulfill()
 //          }
 //        }
+//          
+//          let floatArray = data.withUnsafeBytes { bytes -> [Float] in
+//              let floatBuffer = bytes.bindMemory(to: Float.self)
+//              return Array(floatBuffer)
+//          }
+//          
+//          // Pass the float array to UnsafeBufferPointer
+//          floatArray.withUnsafeBufferPointer { buffer in
+//              add(samples: buffer)
+//          }
 //        
 //        // finally, send the audio data.  This can be called repeatedly as new data become available if you want to live stream
-//        audio.add(samples: data)
+//        //  audio.add(samples: data)
 //        
 //        // tell the server no more data will come
 //        audio.endSamples()
@@ -111,7 +123,7 @@ final class w3w_swift_wrapperTests: XCTestCase {
 //        waitForExpectations(timeout: 60.0, handler: nil)
 //      }
 //    }
-    
+//    
 //  }
 #endif
   

--- a/W3WSwiftVoiceApi.podspec
+++ b/W3WSwiftVoiceApi.podspec
@@ -1,15 +1,15 @@
 Pod::Spec.new do |s|
   s.name        = "W3WSwiftVoiceApi"
-  s.version     = "4.0.0"
-  s.summary     = "w3w-swift-wrapper allows you to convert a 3 word address to coordinates or to convert coordinates to a 3 word address"
-  s.homepage    = "https://github.com/what3words/w3w-swift-wrapper"
+  s.version     = "2.0.0"
+  s.summary     = "w3w-swift-voice-api allows you to convert a spoken 3 word address in audio to a list of three word address suggestions"
+  s.homepage    = "https://github.com/what3words/w3w-swift-voice-api"
   s.license     = { :type => "MIT" }
   s.authors     = { "what3words" => "support@what3words.com" }
 
-  s.requires_arc = true
+  #s.requires_arc = true
   s.osx.deployment_target = "10.13"
   s.ios.deployment_target = "11.0"
-  s.source   = { :git => "https://github.com/what3words/w3w-swift-voice-api.git", :tag => "v1.0.0", :branch => "task/MT-6899-Core-lib-update-does-not-support-cocoapods"}
+  s.source   = { :git => "https://github.com/what3words/w3w-swift-voice-api.git"}
   s.source_files = "Sources/W3WSwiftVoiceApi/**/*.swift"
   s.swift_version = '5.0'
   s.dependency 'W3WSwiftCore', '~> 1.1.2'

--- a/W3WSwiftVoiceApi.podspec
+++ b/W3WSwiftVoiceApi.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name        = "W3WSwiftVoiceApi"
+  s.version     = "4.0.0"
+  s.summary     = "w3w-swift-wrapper allows you to convert a 3 word address to coordinates or to convert coordinates to a 3 word address"
+  s.homepage    = "https://github.com/what3words/w3w-swift-wrapper"
+  s.license     = { :type => "MIT" }
+  s.authors     = { "what3words" => "support@what3words.com" }
+
+  s.requires_arc = true
+  s.osx.deployment_target = "10.13"
+  s.ios.deployment_target = "11.0"
+  s.source   = { :git => "https://github.com/what3words/w3w-swift-voice-api.git", :tag => "v1.0.0", :branch => "task/MT-6899-Core-lib-update-does-not-support-cocoapods"}
+  s.source_files = "Sources/W3WSwiftVoiceApi/**/*.swift"
+  s.swift_version = '5.0'
+  s.dependency 'W3WSwiftCore', '~> 1.1.2'
+end


### PR DESCRIPTION
This PR adds a podspec file to enable support for CocoaPods in the library.